### PR TITLE
Wrap usage command in backticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ The Mage Project Integrity Checker checks a magento install for modified core fi
 
 The mageintegriycheck.php file is the only requirement to use.
 
-Usage: php mageintegriycheck.php <path to magento root>
+Usage: `php mageintegriycheck.php <path to magento root>`
 
 Any modified core file will be returned.


### PR DESCRIPTION
I noticed that the argument for the usage command was missing and noticed that it just wasn't rendered. I gave it inline code formatting, so it can be seen.